### PR TITLE
Feat:AI 인사이트 목록 및 상세 페이지 API 연동 완료

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.84.1",
+        "axios": "^1.11.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.1",
@@ -1926,6 +1927,12 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -1962,6 +1969,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2039,6 +2057,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2157,6 +2188,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2250,6 +2293,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -2263,6 +2315,20 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2284,6 +2350,51 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.8",
@@ -2653,6 +2764,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2668,6 +2799,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fraction.js": {
@@ -2703,7 +2850,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2717,6 +2863,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -2792,6 +2975,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2809,11 +3004,37 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3108,6 +3329,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3130,6 +3360,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3583,6 +3834,12 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.84.1",
+    "axios": "^1.11.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.1",

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const baseURL = import.meta.env.VITE_API_BASE_URL;
+
+const axiosInstance = axios.create({
+  baseURL: baseURL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default axiosInstance;

--- a/src/api/insightAPI.ts
+++ b/src/api/insightAPI.ts
@@ -1,0 +1,27 @@
+import axiosInstance from './axiosInstance'; 
+import type { InsightsResponse, InsightDetail } from '../types'; 
+
+export const getInsights = async (): Promise<InsightsResponse> => {
+  try {
+    const response = await axiosInstance.get<InsightsResponse>('/api/v1/insights');
+    
+    return response.data;
+  } catch (error) {
+    console.error("인사이트 목록을 불러오는 중 오류 발생:", error);
+    throw error;
+  }
+};
+
+/**
+ * @param {string} insightId - 조회할 인사이트 ID
+ */
+export const getInsightById = async (insightId: string): Promise<InsightDetail> => {
+  try {
+    const response = await axiosInstance.get<InsightDetail>(`/api/v1/insights/${insightId}`);
+  
+    return response.data;
+  } catch (error) {
+    console.error(`${insightId}번 인사이트 상세 정보를 불러오는 중 오류 발생:`, error);
+    throw error;
+  }
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -68,7 +68,7 @@ const Home: React.FC = () => {
             label="리포트"
             onClick={() => navigate('/analytics')}
           />
-          <FeatureIcon image={fantasySvg} label="AI 인사이트" />
+          <FeatureIcon image={fantasySvg} label="AI 인사이트" onClick = {() => navigate('/insight')} />
           <FeatureIcon
             image={webadSvg}
             label="캠페인"

--- a/src/pages/Insight.tsx
+++ b/src/pages/Insight.tsx
@@ -1,107 +1,42 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Layout } from '../components/common';
+import { getInsights } from '../api/insightAPI';
+import type { NewStrategy, RecommendedStrategy } from '../types';
+
 import iconSvg from '../assets/icon.svg'; 
 import backIcon from '../assets/back.svg'; 
 import chevronRightIcon from '../assets/chevron-right.svg'; 
 
-interface NewStrategy {
-  id: string; //API : 'insight_001'같은 형태
-  title: string;
-  reason_summary: {
-      icon: string;
-      text: string; // subtitle 대신 text로 변경
-  }
-  created_at: string;
-  isNew: boolean; // api에는 없지만, 새로 추가된 전략을 구분하기 위한 플래그임
-}
-
-interface RecommendedStrategy {
-  id: string; // API : 'insight_001'같은 형태
-  icon: string;
-  title: string;
-  tags: { text: string; type: 'growth' | 'retention' | 'expansion' }[]; // 해당 태그는 백 api 추가 가능한지 확인
-  // icon, tags - reason_summary로 묶어야 하는지 확인(api 수정되는 거 확인)
-}
-
-const mockInsightData = {
-  newStrategies: [
-    {
-      id: 'insight_001',
-      icon: '📈',
-      title: '주말 점심 할인 캠페인 제안',
-      subtitle: '최근 3주간 점심 시간대 매출 상승',
-      date: '2025.08.01.',
-      isNew: true,
-    },
-    {
-      id: 'insight_002',
-      icon: '📣',
-      title: 'SNS 광고 예산 확대 필요',
-      subtitle: 'SNS 유입 전환율이 평균보다 2배 높음',
-      date: '2025.07.30.',
-      isNew: true,
-    },
-    {
-      id: 'insight_003',
-      icon: '🥐',
-      title: '브런치 세트 프로모션 제안',
-      subtitle: '브런치 키워드 상권 내 검색량 40%',
-      date: '2025.08.05.',
-      isNew: true,
-    },
-  ],
-  recommendedStrategies: [
-     {
-      id: 'insight_004', // 기존 AI 추천 전략 id는 추후 api 확인 후 수정
-      icon: '🍽',
-      title: '주말 저녁 방문 유도 프로모션 제안',
-      tags: [
-        { text: '#매출상승', type: 'growth' }, // 노란색 계열
-        { text: '#신규고객유입', type: 'growth' }
-      ],
-    },
-    {
-      id: 'insight_005',
-      icon: '✉️',
-      title: '고객 맞춤 이메일 캠페인 제안',
-      tags: [
-        { text: '#고객유지', type: 'retention' }, // 파란색 계열
-        { text: '#충성도향상', type: 'retention' }
-      ],
-    },
-    {
-      id: 'insight_006',
-      icon: '📱',
-      title: 'SNS 이벤트 참여 유도 캠페인',
-      tags: [
-        { text: '#참여율증가', type: 'retention' },
-        { text: '#참여율증가', type: 'retention' }
-      ],
-    },
-    {
-      id: 'insight_007',
-      icon: '📍',
-      title: '신규 상권 대상 타겟 광고 전략',
-      tags: [
-        { text: '#시장확대', type: 'expansion' }, // 빨간색 계열
-        { text: '#신규진입', type: 'expansion' }
-      ],
-    },
-    {
-      id: 'insight_008',
-      icon: '☕',
-      title: '점심 타임 직장인 타겟 쿠폰 발송',
-      tags: [
-        { text: '#시간대마케팅', type: 'expansion' },
-        { text: '#반복구매유도', type: 'retention' }
-      ],
-    },
-  ],
-};
 
 const Insight: React.FC = () => {
   const navigate = useNavigate();
+
+  const [newStrategies, setNewStrategies] = useState<NewStrategy[]>([]);
+  const [recommendedStrategies, setRecommendedStrategies] = useState<RecommendedStrategy[]>([]);
+
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchInsights = async () => {
+      try {
+        setLoading(true);
+        const data = await getInsights();
+        setNewStrategies(data.new_strategies);
+        setRecommendedStrategies(data.recommended_strategies);
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchInsights();
+  }, []);
+
    const handleCardClick = (id: string) => {
     navigate(`/insight/${id}`);
    };
@@ -109,17 +44,25 @@ const Insight: React.FC = () => {
    const getTagClasses = (type: 'growth' | 'retention' | 'expansion') => {
     switch (type) {
       case 'growth':
-        return 'font-semibold text-[#E4A700] bg-[#FEF8D8]'; // 노란색 계열(growth)
+        return 'font-semibold text-[#E4A700] bg-[#FEF8D8]'; 
       case 'retention':
-        return 'font-semibold text-[#3892E3] bg-[#E2F1FF]'; // 파란색 계열(retention)
+        return 'font-semibold text-[#3892E3] bg-[#E2F1FF]'; 
       case 'expansion':
-        return 'font-semibold text-[#FF7171] bg-[#F5F5F5]'; // 빨간색 계열(expansion)
+        return 'font-semibold text-[#FF7171] bg-[#F5F5F5]'; 
     }
   };
 
+  if (loading) {
+    return <Layout showBottomTab={false}><div className="p-7 text-center">로딩 중...</div></Layout>;
+  }
+
+  if( error) {
+    return <Layout showBottomTab={false}><div className="p-7 text-center">데이터를 불러오는 데 실패했습니다.</div></Layout>;
+  }
+
   return (
     <Layout showBottomTab={false}>
-        {/* Header */}
+        
       <div className="flex items-center justify-between px-7 py-4 z-10 border-b border-gray-100">
           <button onClick={() => navigate(-1)} className="flex items-center justify-center w-8 h-8">
             <img src={backIcon} alt="뒤로 가기" className="w-6 h-6" />
@@ -136,33 +79,33 @@ const Insight: React.FC = () => {
         <div className="p-7 space-y-6">
           <div className="space-y-8">
 
-            {/* 새로운 AI 추천 전략 섹션 */}
+            
             <section>
               <div className="flex justify-between items-center self-stretch mb-4">
                 <h2 className="text-[#121212] text-lg font-bold leading-[150%] tracking-[-0.18px]">
                   새로운 AI 추천 전략
                 </h2>
                 <p className="text-[#121212] text-xs font-medium leading-[150%]">
-                  총 <span className="text-[#3892E3] font-bold">{mockInsightData.newStrategies.length}</span>건{/* 총 건수 연결 필요 */}
+                  총 <span className="text-[#3892E3] font-bold">{newStrategies.length}</span>건
                 </p>
               </div>
 
-              {/* 카드 리스트(3개 한 묶음)*/}
+              
               <div className="flex flex-col gap-2">
-                {mockInsightData.newStrategies.map((strategy) => (
+                {newStrategies.map((strategy) => (
                   <div 
                     key={strategy.id} 
                     onClick={() => handleCardClick(strategy.id)}
                     className="flex items-start justify-between p-4 gap-4 rounded-xl bg-[#FFF8E1] shadow-[0_1px_3px_0_rgba(18,18,18,0.08)] cursor-pointer active:bg-[#fdeec9] transition-colors"
                   >
-                    <div className="flex flex-col flex-grow gap-1"> {/* 텍스트 전체를 감싸는 세로 프레임 */}
+                    <div className="flex flex-col flex-grow gap-1"> 
                       <p className="text-[#767676] text-[10px] font-medium leading-[140%] tracking-[0.1px]">
-                        생성일 {strategy.date}
+                        생성일 {strategy.created_at.substring(0, 10 )}
                       </p>
 
-                      {/* 아이콘 + [N뱃지 + 제목을 묶는 가로 프레임] */}
+                      
                       <div className="flex items-center gap-2 self-stretch"> 
-                        <span className="text-sm text-[#767676]">{strategy.icon}</span>
+                        <span className="text-sm text-[#767676]">{strategy.reason_summary.icon}</span>
                         {strategy.isNew && (
                           <div className="flex justify-center items-center py-[1px] px-1 rounded-full bg-[#FF7171]">
                             <span className="text-white text-[10px] font-bold">N</span>
@@ -174,7 +117,7 @@ const Insight: React.FC = () => {
                       </div>
 
                       <p className="text-[#767676] text-sm font-normal leading-[160%] self-stretch">
-                        {strategy.subtitle}
+                        {strategy.reason_summary.text}
                       </p>
                     </div>
                     
@@ -186,15 +129,15 @@ const Insight: React.FC = () => {
               </div>
             </section>
 
-            {/* AI 추천 전략 섹션 */}
+            
             <section className="pb-4">
                   <h2 className="text-[#121212] text-lg font-bold leading-[150%] tracking-[-0.18px] mb-4">AI 추천 전략</h2>
                   
-                  {/* 모든 카드를 감싸는 외부 컨테이너를 추가 */}
+                  
                   <div className="bg-[#FFFEFB] rounded-2xl p-2 shadow-[0_1px_3px_0_rgba(18,18,18,0.08)]">
 
                     <div className="divide-y divide-gray-100">
-                      {mockInsightData.recommendedStrategies.map((strategy) => (
+                      {recommendedStrategies.map((strategy) => (
                         <div 
                           key={strategy.id}
                           onClick={() => handleCardClick(strategy.id)}
@@ -232,5 +175,6 @@ const Insight: React.FC = () => {
     </Layout>
   );
 };
+
 
 export default Insight;

--- a/src/pages/InsightDetail.tsx
+++ b/src/pages/InsightDetail.tsx
@@ -1,61 +1,25 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Layout } from '../components/common';
+import { getInsightById } from '../api/insightAPI';
+import type { InsightDetail as InsightDetailType } from '../types';
+
 import iconSvg from '../assets/icon.svg';
 import backIcon from '../assets/back.svg';
 import lightbulb from '../assets/lightbulb.svg';
 
-const mockDetailData = {
-  id: 'insight_001',
-  tags: [
-    { text: '#프로모션', type: 'growth' },
-    { text: '#시간대마케팅', type: 'retention' },
-  ],
-  title: '주말 점심 할인 캠페인 제안',
-  summary: '상권 주변 기숙사생들의 주말 점심 소비 패턴을 분석하여 매출 증대를 위한 타겟팅 전략을 제안합니다.',
-  analysis: {
-    title: 'AI 분석 근거',
-    items: [
-      {
-        icon: '🧾',
-        title: '매출 데이터',
-        description: '최근 3주간 주말 점심 매출이 평균 대비 18% 상승하였습니다.',
-      },
-      {
-        icon: '📍',
-        title: '시장 데이터',
-        description: '상권 내 기숙사생들의 주말 외식 빈도가 다른 요일 대비 높게 나타났습니다.',
-      },
-      {
-        icon: '💬',
-        title: 'SNS 트렌드',
-        description: '“기숙사”, “점심 메뉴 추천”, “혼밥 맛집” 관련 키워드가 주말 점심 시간대에 SNS에서 급증하였습니다.',
-      },
-    ],
-  },
-  recommendation: {
-    title: '추천 실행 계획',
-    item: {
-      icon: '🎯',
-      title: 'SNS 기반 주말 점심 타겟팅 프로모션 제안',
-      description: '주변 기숙사 반경 1.5km 내 타겟 유저에게 배달앱 쿠폰 + SNS 홍보용 메뉴 카드 콘텐츠 조합을 추천합니다.\n점심 전 타이밍(오전 11시)에 메시지를 발송하여 “혼밥 할인 세트”를 노출하세요!',
-    },
-  },
-};
 
-// Insight.tsx의 getTagClasses 재사용
 const getTagClasses = (type: 'growth' | 'retention' | 'expansion') => {
     switch (type) {
       case 'growth':
-        return 'text-[#E4A700] bg-[#FFF8E1]'; // 노란색 계열
+        return 'text-[#E4A700] bg-[#FFF8E1]'; 
       case 'retention':
-        return 'text-[#3892E3] bg-[#E2F1FF]'; // 파란색 계열
+        return 'text-[#3892E3] bg-[#E2F1FF]'; 
       case 'expansion':
-        return 'text-[#FF7171] bg-[#F5F5F5]'; // 빨간색 계열
+        return 'text-[#FF7171] bg-[#F5F5F5]'; 
     }
 };
 
-// AI 분석 근거 카드
 const AnalysisCard: React.FC<{ icon: string; title: string; description: string }> = ({ icon, title, description }) => (
   <div className="rounded-2xl bg-white p-4 shadow-[0_1px_3px_0_rgba(18,18,18,0.08)] space-y-2">
     <div className="flex items-center gap-2">
@@ -71,14 +35,46 @@ const AnalysisCard: React.FC<{ icon: string; title: string; description: string 
 
 const InsightDetail: React.FC = () => {
   const navigate = useNavigate();
-  const { id } = useParams<{ id: string }>(); // URL에서 insight id를 가져옴
+  const { id } = useParams<{ id: string }>(); 
+  const [insightDetail, setInsightDetail] = useState<InsightDetailType | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<Error | null>(null);
 
-  // 추후 api 호출, 데이터 받아오는 로직 작성
-  const data = mockDetailData;
+  useEffect(() => {
+    if (!id) return;
 
+    const fetchInsightsDetail = async () => {
+      try {
+        setLoading(true);
+        const data = await getInsightById(id);
+        setInsightDetail(data);
+      } catch (err) {
+        if (err instanceof Error) {
+          setError(err);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchInsightsDetail();
+  }, [id]);
+
+  if (loading) {
+    return <Layout showBottomTab={false}><div className="p-7 text-center">상세 정보를 불러오는 중...</div></Layout>;
+  }
+
+  if (error) {
+    return <Layout showBottomTab={false}><div className="p-7 text-center">정보를 불러오는 데 실패했습니다.</div></Layout>;
+  }
+  if (!insightDetail) {
+    return <Layout showBottomTab={false}><div className="p-7 text-center">죄송하지만 AI가 제공하지 않는 인사이트입니다.</div></Layout>;
+  }
+
+  
   return (
     <Layout showBottomTab={false}> 
-      {/* Header */}
+      
       <div className="flex items-center justify-between px-7 py-4 z-10 border-b border-gray-100">
         <button onClick={() => navigate(-1)} className="flex items-center justify-center w-8 h-8">
           <img src={backIcon} alt="뒤로 가기" className="w-6 h-6" />
@@ -89,12 +85,12 @@ const InsightDetail: React.FC = () => {
         </div>
       </div>
 
-      {/* Body */}
+      
       <div className="min-h-screen bg-gray2">
         <div className="p-7 space-y-6">
           <div className="space-y-8">
 
-            {/* 상단*/}
+            
             <div className="space-y-6">
               <div className = "flex justify-center">
                 <img src={lightbulb} alt="인사이트 아이콘" className="w-15 h-15" />
@@ -102,9 +98,9 @@ const InsightDetail: React.FC = () => {
 
               <section className="flex flex-col items-center gap-2 text-center">
 
-                {/* tag */}
+                
                 <div className="flex flex-wrap justify-center gap-2">
-                  {data.tags.map((tag, index) => (
+                  {insightDetail.tags.map((tag, index) => (
                     <span 
                       key={index}
                       className={`text-xs font-medium rounded-full px-3 py-1.5 ${getTagClasses(tag.type as any)}`}
@@ -114,23 +110,23 @@ const InsightDetail: React.FC = () => {
                   ))}
                 </div>
 
-                {/* title */}
+                
                 <h2 className="text-2xl font-bold text-[#121212] break-keep">
-                  {data.title}
+                  {insightDetail.title}
                 </h2>
 
-                {/* summary */}
+                
                 <p className="text-l text-[#121212] leading-relaxed">
-                  {data.summary}
+                  {insightDetail.summary}
                 </p>
               </section>
             </div>
 
-            {/* AI 분석 근거 및 추천 실행 계획 */}
+            
             <section>
                <div className="flex flex-col gap-8">
 
-                {/*1. AI 분석 근거*/}
+                
                 <div className='flex flex-col gap-2'>
                     <div className="flex flex-row gap-4 items-start">
 
@@ -140,18 +136,18 @@ const InsightDetail: React.FC = () => {
 
                       <div className="flex-grow">
                         <h3 className="text-lg font-bold text-gray-800 mb-4">
-                          {data.analysis.title}
+                          {insightDetail.analysis.title}
                         </h3>
                       </div>
                     </div>
                     <div className="space-y-2">
-                        {data.analysis.items.map((item, index) => (
+                        {insightDetail.analysis.items.map((item, index) => (
                           <AnalysisCard key={index} {...item} />
                         ))}
                     </div>
                 </div>
                 
-                {/* dot */}
+                
                 <div className="flex justify-center">
                   <div className="flex flex-col items-center gap-6">
                     <div 
@@ -175,7 +171,7 @@ const InsightDetail: React.FC = () => {
                   </div>
                 </div>
 
-                {/* 2. 추천 실행 계획 */}
+                
                 <div className='flex flex-col gap-2'>
                   <div className="flex flex-row gap-4 items-start">
 
@@ -185,18 +181,18 @@ const InsightDetail: React.FC = () => {
 
                     <div className="flex-grow">
                       <h3 className="text-lg font-bold text-gray-800 mb-4">
-                          {data.recommendation.title}
+                          {insightDetail.recommendation.title}
                       </h3>
                     </div>
                   </div>
                       
                   <div className="rounded-2xl bg-[#FFFBEA] p-4 space-y-2 shadow-[0_1px_3px_0_rgba(18,18,18,0.08)]">
                     <div className="flex items-center gap-2">
-                       <span role="img" aria-label="추천 아이콘" className="text-lg">{data.recommendation.item.icon}</span>
-                       <p className="font-semibold text-[#121212]">{data.recommendation.item.title}</p>
+                       <span role="img" aria-label="추천 아이콘" className="text-lg">{insightDetail.recommendation.item.icon}</span>
+                       <p className="font-semibold text-[#121212]">{insightDetail.recommendation.item.title}</p>
                     </div>
                     <p className="text-sm text-[#767676] whitespace-pre-line leading-relaxed">
-                            {data.recommendation.item.description}
+                            {insightDetail.recommendation.item.description}
                     </p>
                   </div>     
                 </div>                                
@@ -207,7 +203,7 @@ const InsightDetail: React.FC = () => {
         </div>
       </div>
 
-      {/* 하단 버튼 */}
+    
       <footer className="static p-8">
         <button
           className="w-full text-black font-semibold py-4 rounded-full"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,3 +24,55 @@ export interface OnboardingStep {
   subtitle?: string;
   isCompleted: boolean;
 }
+
+export interface NewStrategy {
+  id: string;
+  title: string;
+  reason_summary: {
+    icon: string;
+    text: string;
+  };
+  created_at: string;
+  isNew: boolean;
+}
+
+export interface RecommendedStrategy {
+  id: string;
+  icon: string;
+  title: string;
+  tags: {
+    text: string;
+    type: 'growth' | 'retention' | 'expansion';
+  }[];
+}
+
+export interface InsightsResponse {
+  new_strategies: NewStrategy[];
+  recommended_strategies: RecommendedStrategy[];
+}
+
+export interface InsightDetail {
+  id: string;
+  tags: {
+    text: string;
+    type: string;
+  }[];
+  title: string;
+  summary: string;
+  analysis: {
+    title: string;
+    items: {
+      icon: string;
+      title: string;
+      description: string;
+    }[];
+  };
+  recommendation: {
+    title: string;
+    item: {
+      icon: string;
+      title: string;
+      description: string;
+    };
+  };
+}


### PR DESCRIPTION
[FEAT] AI 인사이트 목록 및 상세 페이지 API 연동

## 작업 내용
- AI 인사이트 목록 페이지(/insight) API 연동 완료
- AI 인사이트 상세 페이지(/insight/:id) API 연동 완료
- API 응답 상태에 따른 로딩, 에러, 빈 데이터 화면 처리 구현

## 참고  사항
- 배포 서버에 insight_011, insight_012의 일부 데이터가 null로 표시되어 해당 id의 인사이트 세부 페이지만 확인되지 않습니다. 데이터 추가 작업은 완료되었고, 추후 서버 작업이 완료되면 잘 보일겁니다!
- 혹시나 데이터가 추가되었을 때 정상적으로 작동하지 않을 경우 수정하여 다시 PR 진행하겠습니다.